### PR TITLE
Fix logical operators and memory leak 

### DIFF
--- a/src/Defines.hpp
+++ b/src/Defines.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -32,7 +32,6 @@
 #include <sstream>
 #include <string.h>
 
-
 #include <limits>
 #include <limits.h>
 
@@ -45,6 +44,7 @@ namespace SGTELIB {
   const double EPSILON = 1E-13;
   const double PI = 3.141592654;
   const double INF = std::numeric_limits<double>::max(); ///< Infinity
+  const double NaN = std::numeric_limits<double>::quiet_NaN();
 
   const bool APPROX_CDF = true;
   // If true, then the lower bound of standard deviation is EPSILON. 

--- a/src/Exception.hpp
+++ b/src/Exception.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -25,7 +25,7 @@
 
 #include "Kernel.hpp"
 
-
+     
 
 
 /*----------------------------------------------------------*/
@@ -199,7 +199,7 @@ SGTELIB::kernel_t SGTELIB::str_to_kernel_type ( const std::string & s ) {
 /*----------------------------------------------------------*/
 SGTELIB::kernel_t SGTELIB::int_to_kernel_type ( const int i ) {
 /*----------------------------------------------------------*/
-  if ( (i<0) or (i>=SGTELIB::NB_KERNEL_TYPES) ){
+  if ( (i<0) || (i>=SGTELIB::NB_KERNEL_TYPES) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
       "int_to_kernel_type: invalid integer "+itos(i) );
   }

--- a/src/Kernel.hpp
+++ b/src/Kernel.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -706,7 +706,7 @@ SGTELIB::Matrix SGTELIB::Matrix::get_col (const int j) const {
 /*---------------------------*/
 SGTELIB::Matrix SGTELIB::Matrix::get_rows  (const int i1, const int i2) const {
 
-  if ( (i1<0) or (i1>_nbRows) or (i2<0) or (i2>_nbRows) or (i1>=i2) ){
+  if ( (i1<0) || (i1>_nbRows) || (i2<0) || (i2>_nbRows) || (i1>=i2) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ , "Matrix::get_rows: bad index" );
   }
 
@@ -727,7 +727,7 @@ SGTELIB::Matrix SGTELIB::Matrix::get_rows  (const int i1, const int i2) const {
 /*---------------------------*/
 SGTELIB::Matrix SGTELIB::Matrix::get_cols  (const int i1, const int i2) const {
 
-  if ( (i1<0) or (i1>_nbCols) or (i2<0) or (i2>_nbCols) or (i1>=i2) ){
+  if ( (i1<0) || (i1>_nbCols) || (i2<0) || (i2>_nbCols) || (i1>=i2) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ , "Matrix::get_cols: bad index" );
   }
 
@@ -748,12 +748,12 @@ SGTELIB::Matrix SGTELIB::Matrix::get_cols  (const int i1, const int i2) const {
 SGTELIB::Matrix SGTELIB::Matrix::get_rows (const std::list<int> & list_rows) const {
 
   // If the list has only one element and this element is -1, then all rows are returned.
-  if ( (list_rows.size()==1) and (list_rows.front()==-1) ){
+  if ( (list_rows.size()==1) && (list_rows.front()==-1) ){
     return *this;
   }
 
   // Otherwise, select the rows
-  const int nbRows = list_rows.size();
+  const int nbRows = static_cast<int>(list_rows.size());
   const int nbCols = _nbCols;
   SGTELIB::Matrix A (_name+"_get_rows",nbRows,nbCols);
   
@@ -775,13 +775,13 @@ SGTELIB::Matrix SGTELIB::Matrix::get_rows (const std::list<int> & list_rows) con
 SGTELIB::Matrix SGTELIB::Matrix::get_cols (const std::list<int> & list_cols) const {
 
   // If the list has only one element and this element is -1, then all rows are returned.
-  if ( (list_cols.size()==1) and (list_cols.front()==-1) ){
+  if ( (list_cols.size()==1) && (list_cols.front()==-1) ){
     return *this;
   }
 
   // Otherwise, select the rows
   const int nbRows = _nbRows;
-  const int nbCols = list_cols.size();
+  const int nbCols = static_cast<int>(list_cols.size());
   SGTELIB::Matrix A (_name+"_get_cols",nbRows,nbCols);
   
   std::list<int>::const_iterator it;
@@ -863,7 +863,7 @@ void SGTELIB::Matrix::display_size ( std::ostream & out ) const {
 /*---------------------------*/
 SGTELIB::Matrix SGTELIB::Matrix::col_vector ( const double * v,
                                               const int n     )  {
-  if (not v){
+  if ( ! v){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ , "Matrix::column_vector: v is null" );
   }  
   SGTELIB::Matrix V("V",n,1);
@@ -878,7 +878,7 @@ SGTELIB::Matrix SGTELIB::Matrix::col_vector ( const double * v,
 /*---------------------------*/
 SGTELIB::Matrix SGTELIB::Matrix::row_vector ( const double * v,
                                               const int n     )  {
-  if (not v){
+  if ( ! v){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ , "Matrix::column_vector: v is null" );
   }  
   SGTELIB::Matrix V("V",1,n);
@@ -1164,7 +1164,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diagA_product ( const SGTELIB::Matrix & A,
     }
     return C;
   }
-  else if ( (na==1) and (ma==n) ){
+  else if ( (na==1) && (ma==n) ){
     // A is a line vector
     for ( i = 0 ; i < n ; i++ ) {
       Aii = A._X[0][i];
@@ -1174,7 +1174,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diagA_product ( const SGTELIB::Matrix & A,
     }
     return C;
   }
-  else if ( (na==n) and (ma==1) ){
+  else if ( (na==n) && (ma==1) ){
     // A is a col vector
     for ( i = 0 ; i < n ; i++ ) {
       Aii = A._X[i][0];
@@ -1210,7 +1210,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diagB_product ( const SGTELIB::Matrix & A,
   int i,j;
   double Bjj;
 
-  if ( (nb==mb) and (mb==n) ){
+  if ( (nb==mb) && (mb==n) ){
     // B is square, use the diag terms
     for ( j = 0 ; j < m ; j++ ) {
       Bjj = B._X[j][j];
@@ -1220,7 +1220,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diagB_product ( const SGTELIB::Matrix & A,
     }
     return C;
   }
-  else if ( (nb==1) and (mb==m) ){
+  else if ( (nb==1) && (mb==m) ){
     // B is a line vector
     for ( j = 0 ; j < m ; j++ ) {
       Bjj = B._X[0][j];
@@ -1230,7 +1230,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diagB_product ( const SGTELIB::Matrix & A,
     }
     return C;
   }
-  else if ( (nb==m) and (mb==1) ){
+  else if ( (nb==m) && (mb==1) ){
     // B is a col vector
     for ( j = 0 ; j < m ; j++ ) {
       Bjj = B._X[j][0];
@@ -1776,7 +1776,7 @@ int SGTELIB::Matrix::count ( void ) const{
   const int nb_cols = get_nb_cols();
   for ( i = 0 ; i < nb_rows ; ++i ) {
     for ( j = 0 ; j < nb_cols ; ++j ){
-      v += (double) (fabs(_X[i][j])>EPSILON);
+      v += (fabs(_X[i][j])>EPSILON)? 1:0 ;
     }
   }
   return v;
@@ -1907,7 +1907,7 @@ SGTELIB::Matrix SGTELIB::Matrix::cholesky_inverse ( double * det ) const {
     double v = 1;
     for (i=0 ; i<n ; i++) v *= L._X[i][i];
     v *= v;
-    if (isnan(v)) v=+INF;
+    if ( isnan(v)) v=+INF;
     *det = v;
   }
 
@@ -2021,7 +2021,7 @@ SGTELIB::Matrix SGTELIB::Matrix::SVD_inverse ( void ) const {
 
   // Perform SVD
   std::string error_msg;
-  SVD_decomposition ( error_msg , U, W, V, 1e+9 );
+  SVD_decomposition ( error_msg , U, W, V, 1000000000 );
 
   // Inverse diag terms of W.
   for (int i=0 ; i<W->get_nb_rows() ; i++){
@@ -2060,7 +2060,7 @@ SGTELIB::Matrix SGTELIB::Matrix::diag ( void ) const{
     A = SGTELIB::Matrix("A",_nbRows,1);   
     for (int i=0 ; i<_nbCols ; i++) A.set(i,0,_X[i][i]);
   }
-  else if ( (_nbCols==1) or (_nbRows==1) ){
+  else if ( (_nbCols==1) || (_nbRows==1) ){
     const int n=std::max(_nbCols,_nbRows);
     A = SGTELIB::Matrix("A",_nbRows,1);   
     for (int i=0 ; i<n ; i++) A.set(i,i,get(i));
@@ -2175,7 +2175,7 @@ bool SGTELIB::Matrix::SVD_decomposition ( std::string & error_msg ,
   int      nm1   = nbCols - 1;
 
   bool   flag;
-  int    i , j , k , l , its , jj , nm = 0;
+  int    i , j , k , l = 0 , its , jj , nm = 0;
   double s , f , h , tmp , c , x , y , z , absf , absg , absh;
 
   const int NITER = 30;
@@ -2426,7 +2426,7 @@ bool SGTELIB::Matrix::has_nan ( void ) const {
   int i , j;
   for ( i = 0 ; i < _nbRows ; ++i ){
     for ( j = 0 ; j < _nbCols ; ++j ){
-      if (std::isnan(_X[i][j])){
+      if ( isnan(_X[i][j])){
         return true;
       }
     }
@@ -2441,7 +2441,7 @@ bool SGTELIB::Matrix::has_inf ( void ) const {
   int i , j;
   for ( i = 0 ; i < _nbRows ; ++i ){
     for ( j = 0 ; j < _nbCols ; ++j ){
-      if (std::isinf(_X[i][j])){
+      if ( isinf(_X[i][j])){
         return true;
       }
     }
@@ -2456,7 +2456,7 @@ void SGTELIB::Matrix::replace_nan ( double d ) {
   int i , j;
   for ( i = 0 ; i < _nbRows ; ++i ){
     for ( j = 0 ; j < _nbCols ; ++j ){
-      if (std::isnan(_X[i][j])){
+      if ( isnan(_X[i][j])){
         _X[i][j] = d;
       }
     }
@@ -2730,7 +2730,7 @@ int SGTELIB::Matrix::find_row (SGTELIB::Matrix & R){
         break;
       }
     }
-    if (not diff) return i;
+    if ( ! diff) return i;
   }
   return -1;
 
@@ -2815,7 +2815,7 @@ SGTELIB::Matrix SGTELIB::Matrix::get_poll_directions ( const SGTELIB::Matrix sca
     }
 
     // Add extended POLL for discrete values
-    if ( (domain[i]==SGTELIB::PARAM_DOMAIN_INTEGER) or
+    if ( (domain[i]==SGTELIB::PARAM_DOMAIN_INTEGER) ||
          (domain[i]==SGTELIB::PARAM_DOMAIN_BOOL) ){
       D._X[i][i] = (i%2==0)?-1:+1;
     }

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate.cpp
+++ b/src/Surrogate.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -236,7 +236,7 @@ bool SGTELIB::Surrogate::build ( void ) {
   // Number of points in the training set.
   _p_ts = _trainingset.get_nb_points();
   //std::cout << _ready << " " << _p_ts << " " << _p_ts_old << "\n";
-  if ( (_ready) and (_p_ts==_p_ts_old) ){
+  if ( (_ready) && (_p_ts==_p_ts_old) ){
     #ifdef SGTELIB_DEBUG
       std::cout << "Surrogate build - SKIP Build\n";
     #endif
@@ -248,10 +248,10 @@ bool SGTELIB::Surrogate::build ( void ) {
 
 
   // Get the number of points used in the surrogate
-  if ( (_selected_points.size()==1) and (_selected_points.front()==-1) )
+  if ( (_selected_points.size()==1) && (_selected_points.front()==-1) )
     _p = _p_ts;
   else  
-    _p = _selected_points.size();
+    _p = static_cast<int>(_selected_points.size());
 
   // Need at least 2 point to build a surrogate.
   if (_p<2){
@@ -270,12 +270,12 @@ bool SGTELIB::Surrogate::build ( void ) {
 
   bool ok;
   ok = init_private();
-  if (not ok) return false;
+  if ( ! ok) return false;
 
   // Optimize parameters
   if (_param.get_nb_parameter_optimization()>0){
     ok = optimize_parameters();
-    if (not ok){
+    if ( ! ok){
       _ready = false;
       return false;
     }
@@ -283,7 +283,7 @@ bool SGTELIB::Surrogate::build ( void ) {
 
   // Build private
   ok = build_private();
-  if (not ok){
+  if ( ! ok){
     _ready = false;
     return false;
   }
@@ -340,7 +340,7 @@ void SGTELIB::Surrogate::check_ready (const std::string & file,
 void SGTELIB::Surrogate::check_ready (const std::string & s) const {
   
   // Check the tag _ready
-  if (not _ready){
+  if ( ! _ready){
     display(std::cout);
     std::cout << "Surrogate: NOT READY! (" << s << ")\n";
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
@@ -509,12 +509,12 @@ void SGTELIB::Surrogate::predict_private (const SGTELIB::Matrix & XXs,
   int i,j;
 
   // Prediction of ZZs
-  if ( (ZZs) or (ei) or (cdf) ){
+  if ( (ZZs) || (ei) || (cdf) ){
     predict_private(XXs,ZZs);
   }
 
   // Prediction of statistical data
-  if ( (std) or (ei) or (cdf) ){
+  if ( (std) || (ei) || (cdf) ){
 
     if (std) std->fill(-SGTELIB::INF);
     else std = new SGTELIB::Matrix("std",pxx,_m);
@@ -610,7 +610,7 @@ void SGTELIB::Surrogate::predict ( const SGTELIB::Matrix & XX ,
 double SGTELIB::Surrogate::get_metric (SGTELIB::metric_t mt , int j){
 
   // Check dimension
-  if ( (j<0) or (j>_m) ){
+  if ( (j<0) || (j>_m) ){
     display(std::cout); 
     std::cout << "j = "<< j << "\n";
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
@@ -618,7 +618,7 @@ double SGTELIB::Surrogate::get_metric (SGTELIB::metric_t mt , int j){
   }
 
   // If the model is not ready, return +INF
-  if (not _ready){ 
+  if ( ! _ready){ 
     #ifdef SGTELIB_DEBUG
       std::cout << get_string() << " is not ready => _metric = +INF\n";
     #endif
@@ -697,7 +697,7 @@ double SGTELIB::Surrogate::get_metric (SGTELIB::metric_t mt , int j){
 /* points                                */
 /*---------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate::get_matrix_Zhs (void){
-  if (not _Zhs){
+  if ( ! _Zhs){
     check_ready(__FILE__,__FUNCTION__,__LINE__);
 
     //#ifdef SGTELIB_DEBUG
@@ -718,7 +718,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate::get_matrix_Zhs (void){
 /*  (Compute the predictive std)        */
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate::get_matrix_Shs (void){
-  if (not _Shs){
+  if ( ! _Shs){
     check_ready(__FILE__,__FUNCTION__,__LINE__);
 
     #ifdef SGTELIB_DEBUG
@@ -736,7 +736,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate::get_matrix_Shs (void){
 
 // If no specific method is defined, consider Svs = Shs.
 const SGTELIB::Matrix * SGTELIB::Surrogate::get_matrix_Svs (void){
-  if (not _Svs){
+  if ( ! _Svs){
     _Svs = new SGTELIB::Matrix("Svs",_p,_m);
     const SGTELIB::Matrix Ds = _trainingset.get_matrix_Ds();
     for (int i=0 ; i<_p ; i++){
@@ -833,7 +833,7 @@ const SGTELIB::Matrix SGTELIB::Surrogate::get_matrix_Sv (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_rmsecv (void){
   check_ready();
-  if (not _metric_rmsecv){
+  if ( ! _metric_rmsecv){
     // Init
     _metric_rmsecv = new double [_m];
 
@@ -862,7 +862,7 @@ void SGTELIB::Surrogate::compute_metric_rmsecv (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_emax (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_emax){
+  if ( ! _metric_emax){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_emax\n";
     #endif
@@ -899,7 +899,7 @@ void SGTELIB::Surrogate::compute_metric_emax (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_emaxcv (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_emaxcv){
+  if ( ! _metric_emaxcv){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_emaxcv\n";
     #endif
@@ -936,7 +936,7 @@ void SGTELIB::Surrogate::compute_metric_emaxcv (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_rmse (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_rmse){
+  if ( ! _metric_rmse){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_rmse\n";
     #endif
@@ -976,7 +976,7 @@ void SGTELIB::Surrogate::compute_metric_rmse (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_oe (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_oe){
+  if ( ! _metric_oe){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_oe\n";
     #endif
@@ -996,7 +996,7 @@ void SGTELIB::Surrogate::compute_metric_oe (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_oecv (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_oecv){
+  if ( ! _metric_oecv){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_oecv\n";
     #endif
@@ -1156,7 +1156,7 @@ void SGTELIB::Surrogate::compute_metric_armsecv (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate::compute_metric_linv (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_linv){
+  if ( ! _metric_linv){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_linv\n";
     #endif
@@ -1209,7 +1209,7 @@ void SGTELIB::Surrogate::compute_order_error (const SGTELIB::Matrix * const Zpre
   //           - Zpred (input of this function)
   // Put the results in "m" (output of this function)
 
-  if (not m){
+  if ( ! m){
     display(std::cout); 
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
                    "compute_order_error(): m is NULL" );
@@ -1570,7 +1570,7 @@ bool SGTELIB::Surrogate::optimize_parameters ( void ) {
         }
 
         // Check for success for each objective
-        if ( (ftry<fmin) or ((ftry==fmin) and (ptry<pmin)) ){
+        if ( (ftry<fmin) || ((ftry==fmin) && (ptry<pmin)) ){
           if (display) std::cout << "(!)";
           xmin = xtry;
           fmin = ftry;
@@ -1580,7 +1580,7 @@ bool SGTELIB::Surrogate::optimize_parameters ( void ) {
         if (display) std::cout << "\n";
       } // End Evaluation (i.e. No Cache Hit)
 
-      if ( (iter) and (success) ) break;
+      if ( (iter) && (success) ) break;
 
     }// END LOOP ON POLL (for i...)
 
@@ -1614,7 +1614,7 @@ bool SGTELIB::Surrogate::optimize_parameters ( void ) {
   }
 
   // Check for Nan
-  if (xmin.has_nan() or xmin.has_inf()) return false;
+  if (xmin.has_nan() || xmin.has_inf()) return false;
 
   delete [] logscale;
   delete [] domain;
@@ -1635,7 +1635,7 @@ double SGTELIB::Surrogate::eval_objective ( void ){
 
   // Build model
   bool ok = build_private();
-  if (not ok) return +INF;
+  if ( ! ok) return +INF;
 
   // Compute metric
   const SGTELIB::metric_t mt = _param.get_metric_type();
@@ -1648,8 +1648,8 @@ double SGTELIB::Surrogate::eval_objective ( void ){
     metric = get_metric(mt,0);
   }
 
-  if (isnan(metric)) return +INF;
-  if (std::isinf(metric)) return +INF;
+  if ( isnan(metric) ) return +INF;
+  if ( isinf(metric) ) return +INF;
   return metric;
 
 }//

--- a/src/Surrogate.hpp
+++ b/src/Surrogate.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_CN.cpp
+++ b/src/Surrogate_CN.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -93,16 +93,16 @@ void SGTELIB::Surrogate_CN::predict_private ( const SGTELIB::Matrix & XXs,
 bool SGTELIB::Surrogate_CN::compute_cv_values (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
 
-  if ((_Zvs) and (_Svs)) return true;
+  if ((_Zvs) && (_Svs)) return true;
 
 
   // Init matrices
-  if (not _Zvs){
+  if ( ! _Zvs){
     _Zvs = new SGTELIB::Matrix ("Zvs",_p,_m);
     _Zvs->set_name("Zvs");
   }
     
-  if (not _Svs){
+  if ( ! _Svs){
     _Svs = new SGTELIB::Matrix ("Svs",_p,_m);
     _Svs->set_name("Svs");
   }
@@ -120,7 +120,7 @@ bool SGTELIB::Surrogate_CN::compute_cv_values (void){
     // Loop on the points of the trainingset
     for (i2=0 ; i2<_p ; i2++){
       d = D.get(i,i2);
-      if ( (i!=i2) and (d<dmin) ){
+      if ( (i!=i2) && (d<dmin) ){
         dmin = d;
         imin = i2;
       }
@@ -139,7 +139,7 @@ bool SGTELIB::Surrogate_CN::compute_cv_values (void){
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_CN::get_matrix_Zhs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _Zhs){
+  if ( ! _Zhs){
     _Zhs = new SGTELIB::Matrix(get_matrix_Zs());
   }
   return _Zhs;
@@ -150,7 +150,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_CN::get_matrix_Zhs (void){
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_CN::get_matrix_Shs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _Shs){
+  if ( ! _Shs){
     _Shs = new SGTELIB::Matrix("Shs",_p,_m);
   }
   return _Shs;

--- a/src/Surrogate_CN.hpp
+++ b/src/Surrogate_CN.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_Ensemble.cpp
+++ b/src/Surrogate_Ensemble.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -250,7 +250,7 @@ bool SGTELIB::Surrogate_Ensemble::build_private ( void ) {
       {
       SGTELIB::Matrix W = _param.get_weight();
       for (k=0 ; k<_kmax ; k++){
-        if (not is_ready(k)){
+        if (! is_ready(k)){
           W.set_row(0.0,k);
         }
       }
@@ -301,7 +301,7 @@ void SGTELIB::Surrogate_Ensemble::compute_active_models ( void ) {
   // (_active[k] is true if the model k is ready AND the weight in k is not null for 
   // at least one output)
   SGTELIB::Matrix W = _param.get_weight();
-  if (not _active){
+  if (! _active){
     _active = new bool [_kmax];
   }
   int k;
@@ -309,7 +309,7 @@ void SGTELIB::Surrogate_Ensemble::compute_active_models ( void ) {
     _active[k] = false;
     if ( is_ready(k) ){
       for (int j=0 ; j<_m ; j++){
-        if ( (_trainingset.get_bbo(j)!=SGTELIB::BBO_DUM) and (W.get(k,j)>EPSILON) ){
+        if ( (_trainingset.get_bbo(j)!=SGTELIB::BBO_DUM) && (W.get(k,j)>EPSILON) ){
           _active[k] = true;
           break;
         }
@@ -342,7 +342,7 @@ void SGTELIB::Surrogate_Ensemble::compute_W_by_select ( void ) {
       for (k=0 ; k<_kmax ; k++){
         if (is_ready(k)){
           metric = _surrogates.at(k)->get_metric(_param.get_metric_type(),j);
-          if (not isnan(metric)) {
+          if (! isnan(metric)) {
             metric_best = std::min(metric,metric_best);
           }
         }
@@ -564,7 +564,7 @@ void SGTELIB::Surrogate_Ensemble::predict_private ( const SGTELIB::Matrix & XXs,
   const SGTELIB::Matrix W = _param.get_weight();
 
   // If no statistical information is required, use the simpler prediction method
-  if (not (std or ei or cdf)){
+  if (! (std || ei || cdf)){
     predict_private ( XXs, ZZ );
     return;
   }
@@ -574,7 +574,7 @@ void SGTELIB::Surrogate_Ensemble::predict_private ( const SGTELIB::Matrix & XXs,
 
   // Init ZZ
   bool delete_ZZ = false;
-  if (not ZZ){
+  if ( ! ZZ){
     // if ZZ is not required, we build it anyway, but delete it in the end
     ZZ = new SGTELIB::Matrix ("ZZ",pxx,_m);
     delete_ZZ = true;
@@ -632,7 +632,7 @@ void SGTELIB::Surrogate_Ensemble::predict_private ( const SGTELIB::Matrix & XXs,
           }
     
           // EI is linear on w
-          if ( (ei) and (_trainingset.get_bbo(j)==SGTELIB::BBO_OBJ) ){
+          if ( (ei) && (_trainingset.get_bbo(j)==SGTELIB::BBO_OBJ) ){
             for (int i=0 ; i<pxx ; i++){
               ei->set(i,j, ei->get(i,j) + w*eik->get(i,j) );
             }// end loop i
@@ -675,7 +675,7 @@ void SGTELIB::Surrogate_Ensemble::predict_private ( const SGTELIB::Matrix & XXs,
 /*       get_matrix_Zvs                 */
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Zvs (void){
-  if (not _Zvs){
+  if ( ! _Zvs){
     #ifdef ENSEMBLE_DEBUG
       check_ready(__FILE__,__FUNCTION__,__LINE__);
     #endif
@@ -711,7 +711,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Zvs (void){
 /*       get_matrix_Zhs                 */
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Zhs (void){
-  if (not _Zhs){
+  if ( ! _Zhs){
     #ifdef ENSEMBLE_DEBUG
       check_ready(__FILE__,__FUNCTION__,__LINE__);
     #endif
@@ -747,7 +747,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Zhs (void){
 /*       get_matrix_Shs                 */
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Shs (void){
-  if (not _Shs){
+  if ( ! _Shs){
     const SGTELIB::Matrix W = _param.get_weight();
     _Shs = new SGTELIB::Matrix("Zv",_p,_m);
     _Shs->fill(0.0);
@@ -791,7 +791,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_Ensemble::get_matrix_Shs (void){
 /*  to know if basic model k is ready   */
 /*--------------------------------------*/
 bool SGTELIB::Surrogate_Ensemble::is_ready (const int k) const{
-  if ((k<0) or (k>=_kmax)){
+  if ((k<0) || (k>=_kmax)){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
                "Surrogate_Ensemble::set_weight_vector (const int k): k out of range" );
   }
@@ -891,7 +891,7 @@ bool SGTELIB::Surrogate_Ensemble::check_weight_vector ( void ) const {
         w = W.get(k,j);
         if (w<-EPSILON)    return true;   
         if (w>1+EPSILON)   return true;
-        if (std::isnan(w)) return true;
+        if ( isnan(w) ) return true;
       }
       s = W.get_col(j).sum();
       if (fabs(s-1.0)>_kready*EPSILON) return true;

--- a/src/Surrogate_Ensemble.hpp
+++ b/src/Surrogate_Ensemble.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_Factory.cpp
+++ b/src/Surrogate_Factory.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_Factory.hpp
+++ b/src/Surrogate_Factory.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_KS.cpp
+++ b/src/Surrogate_KS.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -59,7 +59,7 @@ void SGTELIB::Surrogate_KS::display_private ( std::ostream & out ) const {
 bool SGTELIB::Surrogate_KS::build_private ( void ) {
 
   // Verify that the kernel is decreasing
-  if (not kernel_is_decreasing(_param.get_kernel_type())){
+  if ( !  kernel_is_decreasing(_param.get_kernel_type())){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
              "Surrogate_KS::build_private(): Kernel must be decreasing for KS model" );
   }
@@ -102,7 +102,7 @@ void SGTELIB::Surrogate_KS::predict_private ( const SGTELIB::Matrix & XXs,
   if (Div.has_inf()){
     // Loop on the points of XXs
     for (ixx=0 ; ixx<pxx ; ixx++){
-      if (std::isinf(Div.get(ixx,0))){
+      if ( isinf(Div.get(ixx,0)) ){
         // Need to use the limit behavior of kernels
         switch (_param.get_kernel_type()){
           case SGTELIB::KERNEL_D1:
@@ -140,7 +140,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_KS::get_matrix_Zvs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
 
   // Check that it's NULL
-  if ( not _Zvs ){
+  if (  !  _Zvs ){
 
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _Zvs\n";
@@ -208,7 +208,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_KS::get_matrix_Zvs (void){
               for (i=0 ; i<_p ; i++){
 
                 d = D.get(i,iv);
-                if ( (i!=iv) and (d<dmin) ){
+                if ( (i!=iv) &&  (d<dmin) ){
                   dmin = d;
                   imin = i;
                 }
@@ -250,7 +250,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_KS::get_matrix_Zhs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
 
   // Check that it's NULL
-  if ( not _Zhs ){
+  if (  !  _Zhs ){
 
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _Zhs\n";

--- a/src/Surrogate_KS.hpp
+++ b/src/Surrogate_KS.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_Kriging.cpp
+++ b/src/Surrogate_Kriging.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -210,7 +210,7 @@ void SGTELIB::Surrogate_Kriging::predict_private (const SGTELIB::Matrix & XXs,
   }
 
   // Prediction of statistical data
-  if ( (ei) or (cdf) ){
+  if ( (ei) || (cdf) ){
     double v;
     if (ei)   ei->fill(-SGTELIB::INF);
     if (cdf) cdf->fill(-SGTELIB::INF);
@@ -256,7 +256,7 @@ void SGTELIB::Surrogate_Kriging::predict_private (const SGTELIB::Matrix & XXs,
 bool SGTELIB::Surrogate_Kriging::compute_cv_values (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
 
-  if ((_Zvs) and (_Svs)) return true;
+  if ((_Zvs) && (_Svs)) return true;
 
   const SGTELIB::Matrix & Zs = get_matrix_Zs();
   const SGTELIB::Matrix RiH = _Ri*_H;
@@ -264,14 +264,14 @@ bool SGTELIB::Surrogate_Kriging::compute_cv_values (void){
   const SGTELIB::Matrix dQ = Q.diag_inverse();
   
   // Init matrices
-  if (not _Zvs){
+  if ( !  _Zvs){
     _Zvs = new SGTELIB::Matrix;
     *_Zvs = Zs - SGTELIB::Matrix::diagA_product(dQ,Q)*Zs;
     _Zvs->replace_nan(+INF);
     _Zvs->set_name("Zvs");
   }
     
-  if (not _Svs){
+  if ( !  _Svs){
     _Svs = new SGTELIB::Matrix ("Svs",_p,_m);
     double q;
     for (int i=0 ; i<_p ; i++){
@@ -305,7 +305,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_Kriging::get_matrix_Svs (void){
 /*--------------------------------------*/
 void SGTELIB::Surrogate_Kriging::compute_metric_linv (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _metric_linv){
+  if ( !  _metric_linv){
     #ifdef SGTELIB_DEBUG
       std::cout << "Compute _metric_linv\n";
     #endif

--- a/src/Surrogate_Kriging.hpp
+++ b/src/Surrogate_Kriging.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_LOWESS.cpp
+++ b/src/Surrogate_LOWESS.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -153,31 +153,31 @@ bool SGTELIB::Surrogate_LOWESS::build_private ( void ) {
 
   delete_matrices();
 
-  if (not _W){
+  if ( !  _W){
     _W = new double [_p];
   } 
-  if (not _A){
+  if ( !  _A){
     _A = new double * [_q];
     for (int j=0 ; j<_q ; j++) _A[j] = new double [_q];
   }
-  if (not _H){
+  if ( !  _H){
     _H = new double * [_p];
     for (int j=0 ; j<_p ; j++) _H[j] = new double [_q];
   }
-  if (not _HWZ){
+  if ( !  _HWZ){
     _HWZ = new double * [_q];
     for (int j=0 ; j<_q ; j++) _HWZ[j] = new double [_m];
   }
-  if (not _u){
+  if ( !  _u){
     _u = new double [_q];
     for (int i=0 ; i<_q ; i++) _u[i] = 0.0;
   }
-  if (not _old_u){
+  if ( !  _old_u){
     _old_u = new double [_q];
     for (int i=0 ; i<_q ; i++) _old_u[i] = 0.0;
   }
   #ifdef SGTELIB_LOWESS_DEV
-    if (not _old_x){
+    if ( !  _old_x){
       _old_x = new double [_n];
       for (int i=0 ; i<_n ; i++) _old_x[i] = 0.0;
     }
@@ -189,6 +189,9 @@ bool SGTELIB::Surrogate_LOWESS::build_private ( void ) {
   #endif
 
   _q_old = _q;
+    
+  // C.Tribes jan 17th, 2017 --- update _p_old to prevent memory leak
+    _p_old = _p;
 
   _ready = true;
   return true;   
@@ -265,7 +268,7 @@ void SGTELIB::Surrogate_LOWESS::predict_private_single ( const SGTELIB::Matrix X
   #ifdef SGTELIB_DEBUG
     std::cout << "mean var = " << mean << " " << var << "\n";
   #endif
-  if ( (mean<0) or (var<0) ){
+  if ( (mean<0) || (var<0) ){
     std::cout << "mean: " << mean << "\n";
     std::cout << "var: " << var << "\n";
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"Error on computation of mean and var" );
@@ -686,7 +689,7 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_LOWESS::get_matrix_Zvs (void){
     std::cout << "Compute Zvs\n";
     std::cout << "==========================\n";
   #endif
-  if (not _Zvs){
+  if ( !  _Zvs){
     _Zvs = new SGTELIB::Matrix("Zvs",_p,_m);
     for (int i=0 ; i<_p ; i++){
       predict_private_single( get_matrix_Xs().get_row(i) , i);

--- a/src/Surrogate_LOWESS.hpp
+++ b/src/Surrogate_LOWESS.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_PRS.cpp
+++ b/src/Surrogate_PRS.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -71,7 +71,7 @@ bool SGTELIB::Surrogate_PRS::build_private ( void ) {
 
   // If _q is too big or there is not enough points, then quit
   if (_q>200) return false;
-  if ( (_q>pvar-1) and (_param.get_ridge()==0) ) return false;
+  if ( (_q>pvar-1) && (_param.get_ridge()==0) ) return false;
 
   // Compute the exponents of the basis functions
   _M = get_PRS_monomes(nvar,_param.get_degree());
@@ -80,7 +80,7 @@ bool SGTELIB::Surrogate_PRS::build_private ( void ) {
   _H = compute_design_matrix ( _M , get_matrix_Xs() );
 
   // Compute alpha
-  if (not compute_alpha()) return false;
+  if ( !  compute_alpha()) return false;
 
   _ready = true; 
   return true;
@@ -176,7 +176,7 @@ void SGTELIB::Surrogate_PRS::predict_private ( const SGTELIB::Matrix & XXs,
 const SGTELIB::Matrix * SGTELIB::Surrogate_PRS::get_matrix_Zvs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
   // Not necessary. Zv is computed in "build".
-  if (not _Zvs){
+  if ( !  _Zvs){
     _Zvs = new SGTELIB::Matrix;
     // Projection matrix
     const SGTELIB::Matrix & Zs = get_matrix_Zs();
@@ -238,7 +238,7 @@ SGTELIB::Matrix SGTELIB::Surrogate_PRS::get_PRS_monomes(const int nvar, const in
         M.add_row(z);
         // Pivot
         i = 0;
-        while ( (i<nvar-1) and (z[i]<=z[i+1]) and ( (z[i]<=1) or (z[i+1]>=d-c+1))  )
+        while ( (i<nvar-1) && (z[i]<=z[i+1]) && ( (z[i]<=1) || (z[i+1]>=d-c+1))  )
           i++;
         // Transfert
         if (i < nvar-1){
@@ -250,9 +250,9 @@ SGTELIB::Matrix SGTELIB::Surrogate_PRS::get_PRS_monomes(const int nvar, const in
           di = d;
           for (j=i+1 ; j<nvar ; j++){
             ci -= (z[j]!=0);
-            di -= z[j];
+            di -= static_cast<int>(z[j]);
           }
-          if ( (ci==0) and (di>0) ){
+          if ( (ci==0) && (di>0) ){
             z[i+1] = z[i+1]+di;
           }
           else{

--- a/src/Surrogate_PRS.hpp
+++ b/src/Surrogate_PRS.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_PRS_CAT.cpp
+++ b/src/Surrogate_PRS_CAT.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -82,7 +82,7 @@ bool SGTELIB::Surrogate_PRS_CAT::build_private ( void ) {
 
   // If _q is too big or there is not enough points, then quit
   if (nb_monomes>100) return false;
-  if ( (_q>pvar-1) and (_param.get_ridge()==0) ) return false;
+  if ( (_q>pvar-1) && (_param.get_ridge()==0) ) return false;
 
   // Compute the exponents of the basis functions (nb there is one less variable
   // as the first one is the cat)

--- a/src/Surrogate_PRS_CAT.hpp
+++ b/src/Surrogate_PRS_CAT.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_PRS_EDGE.cpp
+++ b/src/Surrogate_PRS_EDGE.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -66,7 +66,7 @@ bool SGTELIB::Surrogate_PRS_EDGE::build_private ( void ) {
 
   // If _q is too big or there is not enough points, then quit
   if (_q>200) return false;
-  if ( (_q>pvar-1) and (_param.get_ridge()==0) ) return false;
+  if ( (_q>pvar-1) && (_param.get_ridge()==0) ) return false;
 
   // Compute the exponents of the basis functions
   _M = get_PRS_monomes(nvar,_param.get_degree());

--- a/src/Surrogate_PRS_EDGE.hpp
+++ b/src/Surrogate_PRS_EDGE.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_Parameters.cpp
+++ b/src/Surrogate_Parameters.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -154,7 +154,7 @@ void SGTELIB::Surrogate_Parameters::read_string (const std::string & model_descr
       std::cout << " (" << field << ")\n";
     #endif   
     // Check if this field is authorized for this type of model.
-    if (not authorized_field(field)){
+    if ( !  authorized_field(field)){
       std::cout << "model_description: " << model_description << "\n";
       throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"Unauthorized field \""+field+"\" in a model of type "+model_type_to_str(_type) );
     }
@@ -162,16 +162,16 @@ void SGTELIB::Surrogate_Parameters::read_string (const std::string & model_descr
       std::cout << "CONTENT: " << content << "\n";
     #endif
     // Read the content 
-    if (not (in_line >> content))
+    if ( !  (in_line >> content))
       throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"Missing content for field \""+field+"\"" );
 
 
 
     // Detect if the content is "OPTIM".
-    content_is_optim = ( streqi(content,"OPTIM") or streqi(content,"OPTIMIZATION") or streqi(content,"OPTIMIZE") );
+    content_is_optim = ( streqi(content,"OPTIM") || streqi(content,"OPTIMIZATION") || streqi(content,"OPTIMIZE") );
 
     // Check if optimization is allowed for this field.
-    if ((content_is_optim) and (not authorized_optim(field))) {
+    if ((content_is_optim) && ( !  authorized_optim(field))) {
       std::cout << "model_description: " << model_description << "\n";
       throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"Field \""+field+"\" cannot be optimized." );
     }
@@ -231,7 +231,7 @@ void SGTELIB::Surrogate_Parameters::read_string (const std::string & model_descr
       _metric_type = str_to_metric_type(content);
     }
     else if ( streqi(field,"BUDGET") ){
-      _budget = stoi(content);
+      _budget = SGTELIB::stoi(content);
     }
     else if ( streqi(field,"PRESET") ){
       _preset = content;
@@ -375,7 +375,7 @@ void SGTELIB::Surrogate_Parameters::check ( void ) {
         throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"kernel_coef must be > 0" );
       if (_ridge<0)
         throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"ridge must be >= 0" );
-      if ( (not kernel_has_parameter(_kernel_type)) and (_kernel_type_status==SGTELIB::STATUS_FIXED) ){
+      if ( ( !  kernel_has_parameter(_kernel_type)) && (_kernel_type_status==SGTELIB::STATUS_FIXED) ){
         // If the kernel coef is not used in this type of kernel, then it should be fixed. 
         _kernel_coef = 1;
         _kernel_coef_status = SGTELIB::STATUS_FIXED;
@@ -383,12 +383,10 @@ void SGTELIB::Surrogate_Parameters::check ( void ) {
       break;
 
     case SGTELIB::LOWESS: 
-      if ( (_degree < 0) or (_degree > 2) )
+      if ( (_degree < 0) || (_degree > 2) )
         throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"degree for LOWESS model must be 0, 1 or 2" );
       if (_ridge<0)
         throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"ridge must be >= 0" );
-      //if (_kernel_coef <= 0)
-      //  throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"kernel_coef must be > 0" );
       if ( (_preset!="D"  ) &&
            (_preset!="DEN") &&
            (_preset!="DGN") &&
@@ -399,9 +397,9 @@ void SGTELIB::Surrogate_Parameters::check ( void ) {
         std::cout << "LOWESS preset : " << _preset << "\n";
         std::cout << "Possible values: D, DEN, DGN, RE, RG, REN, RGN.\n";
         throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"preset not recognized" );
-      if (!SGTELIB::kernel_is_decreasing(_kernel_type))
-        throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"kernel_type must be decreasing" );
       }
+      if ( ! SGTELIB::kernel_is_decreasing( _kernel_type ) )
+        throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"kernel_type must be decreasing" );
       break;
 
     case SGTELIB::ENSEMBLE: 
@@ -828,7 +826,7 @@ void SGTELIB::Surrogate_Parameters::get_x_bounds ( SGTELIB::Matrix * LB ,
                                                    SGTELIB::param_domain_t * domain,
                                                    bool * logscale ){
 
-    if ( (not LB) or (not UB) or (not domain) or (not logscale) ){
+    if ( ( ! LB) || ( ! UB) || ( ! domain) || ( ! logscale) ){
       std::cout << LB << " " << UB << " " << domain << " " << logscale << "\n";
       throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"Pointers are NULL." );
     }
@@ -933,7 +931,7 @@ void SGTELIB::Surrogate_Parameters::get_x_bounds ( SGTELIB::Matrix * LB ,
         std::cout << "LB (=" << LB->get(j) << ") >= UB (=" << UB->get(j) << ")\n";
       }
       // Check that only continuous variables are using a log scale
-      if ( (logscale[j]) and (domain[j]!=SGTELIB::PARAM_DOMAIN_CONTINUOUS) ){
+      if ( (logscale[j]) && (domain[j]!=SGTELIB::PARAM_DOMAIN_CONTINUOUS) ){
         error=true;
         std::cout << "Variable " << j << "\n";
         std::cout << "Uses logscale and is not continuous.\n";
@@ -1039,7 +1037,7 @@ bool SGTELIB::Surrogate_Parameters::check_x ( void ){
           }
           break;
         case SGTELIB::PARAM_DOMAIN_BOOL:
-          if ((X[j]!=0) and (X[j]!=1)){
+          if ((X[j]!=0) && (X[j]!=1)){
             error=true;
             std::cout << "Variable " << j << " (Boolean)\n";
             std::cout << "X[" << j << "]=" << X[j] << " is not a boolean\n";
@@ -1066,7 +1064,7 @@ bool SGTELIB::Surrogate_Parameters::check_x ( void ){
     delete UB;
     delete [] domain; 
 
-    return (not error);
+    return ( !  error);
 }//
 
 
@@ -1155,8 +1153,8 @@ double SGTELIB::Surrogate_Parameters::get_x_penalty ( void ){
     }
   }
 
-  if (std::isinf(pen)) pen=+INF;
-  if (std::isnan(pen)) pen=+INF;
+  if ( isinf(pen) ) pen=+INF;
+  if ( isnan(pen) ) pen=+INF;
   return pen;
 }
 

--- a/src/Surrogate_Parameters.hpp
+++ b/src/Surrogate_Parameters.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/Surrogate_RBF.cpp
+++ b/src/Surrogate_RBF.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -39,7 +39,7 @@ SGTELIB::Surrogate_RBF::Surrogate_RBF ( SGTELIB::TrainingSet & trainingset,
   _HtH               ( "HtH",0,0           ),
   _HtZ               ( "HtZ",0,0           ),
   _Ai                ( "Ai",0,0            ),
-  _ALPHA             ( "alpha",0,0         ),
+  _Alpha             ( "alpha",0,0         ),
   _selected_kernel   (1,-1                 ){
   #ifdef SGTELIB_DEBUG
     std::cout << "constructor RBF\n";
@@ -148,7 +148,7 @@ bool SGTELIB::Surrogate_RBF::build_private ( void ) {
     // Inverte matrix
     _Ai = _H.lu_inverse();
     // Product (only the p first rows of Ai)
-    _ALPHA = SGTELIB::Matrix::subset_product(_Ai,Zs,-1,_p,-1);
+    _Alpha = SGTELIB::Matrix::subset_product(_Ai,Zs,-1,_p,-1);
   }
   else{
     // =========================================
@@ -181,11 +181,11 @@ bool SGTELIB::Surrogate_RBF::build_private ( void ) {
       for (int i=0 ; i<_qrbf ; i++) A.add(i,i,r);
     }
     _Ai = A.cholesky_inverse();
-    _ALPHA = _Ai*_HtZ;
+    _Alpha = _Ai*_HtZ;
   }
 
   // Check for Nan  
-  if (_ALPHA.has_nan()){
+  if (_Alpha.has_nan()){
     return false;
   }
 
@@ -264,7 +264,7 @@ const SGTELIB::Matrix SGTELIB::Surrogate_RBF::compute_design_matrix ( const SGTE
 void SGTELIB::Surrogate_RBF::predict_private ( const SGTELIB::Matrix & XXs,
                                                      SGTELIB::Matrix * ZZs) {
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  *ZZs = compute_design_matrix(XXs,false) * _ALPHA;
+  *ZZs = compute_design_matrix(XXs,false) * _Alpha;
 }//
 
 /*--------------------------------------*/
@@ -272,7 +272,7 @@ void SGTELIB::Surrogate_RBF::predict_private ( const SGTELIB::Matrix & XXs,
 /*--------------------------------------*/
 const SGTELIB::Matrix * SGTELIB::Surrogate_RBF::get_matrix_Zvs (void){
   check_ready(__FILE__,__FUNCTION__,__LINE__);
-  if (not _Zvs){
+  if ( ! _Zvs){
 
     // Init _Zvs
     _Zvs = new SGTELIB::Matrix;
@@ -282,13 +282,13 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_RBF::get_matrix_Zvs (void){
       //============================================
       // ORTHOGONALITY CONSTRAINTS
       //============================================
-      SGTELIB::Matrix dAiAlpha = SGTELIB::Matrix::diagA_product(_Ai.diag_inverse(),_ALPHA);
+      SGTELIB::Matrix dAiAlpha = SGTELIB::Matrix::diagA_product(_Ai.diag_inverse(),_Alpha);
       dAiAlpha.remove_rows(_qprs);
       *_Zvs = Zs-dAiAlpha;
     }
     else{
       //SGTELIB::Matrix dPiPZs    = SGTELIB::Matrix::get_matrix_dPiPZs(_Ai,_H,Zs);
-      SGTELIB::Matrix dPiPZs = SGTELIB::Matrix::get_matrix_dPiPZs(_Ai,_H,Zs,_ALPHA);
+      SGTELIB::Matrix dPiPZs = SGTELIB::Matrix::get_matrix_dPiPZs(_Ai,_H,Zs,_Alpha);
     
       // dPi is the inverse of the diag of P 
       // Compute _Zv = Zs - dPi*P*Zs
@@ -301,5 +301,3 @@ const SGTELIB::Matrix * SGTELIB::Surrogate_RBF::get_matrix_Zvs (void){
   }
   return _Zvs;
 }//
-
-

--- a/src/Surrogate_RBF.hpp
+++ b/src/Surrogate_RBF.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -54,7 +54,7 @@ namespace SGTELIB {
     SGTELIB::Matrix _HtH; // H'*H
     SGTELIB::Matrix _HtZ; // H'*Z
     SGTELIB::Matrix _Ai; // inverse of H or Ht*H+r*J
-    SGTELIB::Matrix _ALPHA; // Coefficients
+    SGTELIB::Matrix _Alpha; // Coefficients
 
     std::list<int> _selected_kernel;
 

--- a/src/Surrogate_Utils.cpp
+++ b/src/Surrogate_Utils.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -24,7 +24,6 @@
 /*-------------------------------------------------------------------------------------*/
 
 #include "Surrogate_Utils.hpp"
-
 
 /*-------------------------------*/
 /*     string comparison         */
@@ -57,19 +56,19 @@ bool SGTELIB::issubstring (const std::string S , const std::string s){
 std::string SGTELIB::deblank ( const std::string & s_input ){
   std::string s = s_input;
   // Remove leading spaces
-  while ( (s.length()) and (s.at(0)==' ') ){
+  while ( (s.length()) && (s.at(0)==' ') ){
     s.erase(0,1);
   }
   // Remove trailing spaces
   size_t i = s.length();
-  while ( (i>0) and (s.at(i-1)==' ') ) {
+  while ( (i>0) && (s.at(i-1)==' ') ) {
     s.erase(i-1,1);
     i--;
   }  
   // Remove double spaces
   i=1;
   while (i+2<s.length()){
-    if ( (s.at(i)==' ') and (s.at(i+1)==' ') ){
+    if ( (s.at(i)==' ') && (s.at(i+1)==' ') ){
       s.erase(i,1);
     }
     else{
@@ -110,7 +109,7 @@ int SGTELIB::count_words( const std::string & s ) {
 void SGTELIB::append_file (const std::string & s , const std::string & file){
   std::string dummy_str;
   std::string cmd;
-  if (not SGTELIB::exists(file)){
+  if ( ! SGTELIB::exists(file)){
     cmd = "touch "+ file;
     dummy_str = system( cmd.c_str() );
   }
@@ -125,7 +124,11 @@ void SGTELIB::append_file (const std::string & s , const std::string & file){
 /*-------------------------------*/
 void SGTELIB::wait (double t) {
   // t is a number of seconds
-  usleep(t*1000000.0);
+#ifdef _MSC_VER
+//    Sleep(t*1000000.0);
+#else
+   usleep(t*1000000.0);
+#endif
 }//
 
 
@@ -134,10 +137,10 @@ void SGTELIB::wait (double t) {
 /*  isdef (not nan nor inf)     */
 /*-------------------------------*/
 bool SGTELIB::isdef ( const double x ) {
-  if (std::isnan(x)) return false;
-  if (std::isinf(x)) return false;
-  if (fabs(x)>=SGTELIB::INF) return false;
-  if (fabs(x)>=1e+16){
+  if ( isnan(x) ) return false;
+  if ( isinf(x) ) return false;
+  if ( fabs(x)>=SGTELIB::INF) return false;
+  if ( fabs(x)>=1e+16){
     return false;
   }
   return true;
@@ -234,7 +237,7 @@ bool SGTELIB::isdigit ( const std::string & s ){
   char c;
   while (it != s.end()){
     c = *it;
-    if ( not ( (std::isdigit(c)) or (c=='+') or (c=='-') or (c=='.') ) ){
+    if ( ! ( ( isdigit(std::string(1,c))) || (c=='+') || (c=='-') || (c=='.') ) ){
       return false;
     }
     it++;
@@ -469,7 +472,7 @@ SGTELIB::distance_t SGTELIB::str_to_distance_type ( const std::string & s ) {
 /*----------------------------------------------------------*/
 SGTELIB::distance_t SGTELIB::int_to_distance_type ( const int i ) {
 /*----------------------------------------------------------*/
-  if ( (i<0) or (i>=SGTELIB::NB_DISTANCE_TYPES) ){
+  if ( (i<0) || (i>=SGTELIB::NB_DISTANCE_TYPES) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
       "int_to_distance_type: invalid integer "+itos(i) );
   }
@@ -512,7 +515,7 @@ SGTELIB::metric_t SGTELIB::str_to_metric_type ( const std::string & s ) {
 /*       Same sign                              */
 /*----------------------------------------------*/
 bool SGTELIB::same_sign (const double a, const double b) {
-  return ( (a*b>0) or ( (fabs(a)<EPSILON) and (fabs(b)<EPSILON) ) );
+  return ( (a*b>0) || ( (fabs(a)<EPSILON) && (fabs(b)<EPSILON) ) );
 }//
 
 
@@ -611,11 +614,12 @@ double SGTELIB::normei ( double fh , double sh , double f_min ) {
 double SGTELIB::gammacdf(double x, double a, double b){
   // a : shape coef
   // b : scale coef
-  if ( (a<=0) or (b<=0) ){
+  if ( (a<=0) || (b<=0) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
              "Surrogate_Utils::gammacdf: a or b is <0" );
   }  
   if (x<EPSILON) return 0.0;
+
   return lower_incomplete_gamma(x/b,a);
 }//
 
@@ -625,11 +629,11 @@ double SGTELIB::gammacdf(double x, double a, double b){
 double SGTELIB::gammacdfinv(double f, double a, double b){
   // a : shape coef
   // b : scale coef
-  if ( (a<=0) or (b<=0) ){
+  if ( (a<=0) || (b<=0) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
              "Surrogate_Utils::gammacdfinv: a or b is <0" );
   }  
-  if ( (f<0) or (f>1) ){
+  if ( (f<0) || (f>1) ){
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
              "Surrogate_Utils::gammacdfinv: f<0 or f>1" );
   }  
@@ -668,24 +672,31 @@ int k = 0;
 //  Stephen Wolfram, The Mathematica Book,Fourth Edition,Cambridge University Press, 1999.
 double SGTELIB::lower_incomplete_gamma ( const double x, double p ){
   // Special cases
-  if ( ( x < EPSILON ) or ( p < EPSILON ) ) return 0;
-  //std::cout << lgamma ( p + 1.0 ) << "\n";
+  if ( ( x < EPSILON ) || ( p < EPSILON ) ) return 0;
+
+#ifdef _MSC_VER
+#if ( _MSC_VER <= 1600 )
+      throw SGTELIB::Exception ( __FILE__ , __LINE__ ,
+                                "Surrogate_Utils:: lgamma function not supported with VisualStudio 2010 or lower " );
+
+#endif
+#endif
   double f = exp( p * log ( x ) - lgamma ( p + 1.0 ) - x );
-  //if ( f < EPSILON ) return 0;
-  // Loop
+
   double dv = 1.0, v = 1.0;
   while (dv > v/1e+9) {
     dv *= x / (++p);
     v += dv;
   }
   return v*f;
+    
 }//
 
 /*----------------------------------------*/
 /*  difference between two timeval, in ms */
 /*----------------------------------------*/
 int SGTELIB::diff_ms(timeval t1, timeval t2){
-  return (((t1.tv_sec - t2.tv_sec) * 1000000) + (t1.tv_usec - t2.tv_usec +500))/1000;
+  return static_cast<int>((((t1.tv_sec - t2.tv_sec) * 1000000) + (t1.tv_usec - t2.tv_usec +500))/1000);
 }//
 
 /*----------------------------------------*/

--- a/src/Surrogate_Utils.hpp
+++ b/src/Surrogate_Utils.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -30,8 +30,27 @@
 #include "Exception.hpp"
 #include "Matrix.hpp"
 #include <sys/stat.h>
+
+// CASE Visual Studio C++ compiler
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#include <io.h>
+#define isnan(x) _isnan(x)
+#define isdigit(x) _isdigit(x)
+#define isinf(x) (!_finite(x))
+
+typedef struct timeval {
+     long tv_sec;
+     long tv_usec;
+} timeval;
+
+#else
 #include <unistd.h>
+#endif
+
+
 #include <cstring>
+#include <cctype>
 
 namespace SGTELIB {
 
@@ -89,7 +108,7 @@ namespace SGTELIB {
     METRIC_LINV   // Inverse of the likelihood
   };
   const int NB_METRIC_TYPES = 11;
-  
+ 
 
   // Diff in ms
   int diff_ms(timeval t1, timeval t2);
@@ -119,7 +138,6 @@ namespace SGTELIB {
 
   // isdef (not nan nor inf)
   bool isdef ( const double x );
-
 
   // rounding:
   int round ( double d );

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -39,7 +39,7 @@ void SGTELIB::test_LOWESS_times ( void ){
 
   const int m = 1;
   const int pp = 6;
-  int n;
+  int n = 0;
 
   for (int in=0 ; in<1 ; in++){
     if (in==0) n = 16;
@@ -200,7 +200,7 @@ std::string SGTELIB::test_quick (const std::string & s , const SGTELIB::Matrix &
   S0 = SGTELIB::Surrogate_Factory(C0,s);
   ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_quick: model ("+s+") is not ready\n";
     return       "test_quick: model ("+s+") is not ready\n";
@@ -248,15 +248,15 @@ std::string SGTELIB::test_quick (const std::string & s , const SGTELIB::Matrix &
   std::cout << oss.str();
 
   for (int j=0 ; j<m ; j++){
-    if ( (std::isnan(emax[j])) or (std::isnan(rmsecv[j])) or (std::isnan(oe[j])) or (std::isnan(oecv[j])) or (std::isnan(linv[j])) ){
+    if ( (isnan(emax[j])) || (isnan(rmsecv[j])) || (isnan(oe[j])) || (isnan(oecv[j])) || (isnan(linv[j])) ){
       std::cout << "There is some nan\n";
       std::cout << "EXIT!\n"; 
-      exit(0.0);
+      exit(0);
     }
-    if ( (std::isinf(emax[j])) or (std::isinf(rmse[j])) or (std::isinf(rmsecv[j])) or (std::isinf(oe[j])) or (std::isinf(oecv[j])) or (std::isinf(linv[j])) ){
+    if ( (isinf(emax[j])) || (isinf(rmse[j])) || ( isinf(rmsecv[j])) || (isinf(oe[j])) || (isinf(oecv[j])) || (isinf(linv[j])) ){
       std::cout << "There is some inf\n";
       std::cout << "EXIT!\n"; 
-      exit(0.0);
+      exit(0);
     }
   }
   delete [] emax;
@@ -295,7 +295,7 @@ std::string SGTELIB::test_pxx (const std::string & s , const SGTELIB::Matrix & X
   bool ready;
   ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout <<  "test_pxx: model ("+s+") is not ready\n";
     return        "test_pxx: model ("+s+") is not ready\n";
@@ -333,7 +333,7 @@ std::string SGTELIB::test_pxx (const std::string & s , const SGTELIB::Matrix & X
         break;
       default:
         std::cout << "ERROR i = " << i << "\n";
-        exit(0.0);
+        exit(0);
     }
 
     // TESTING POINT(S)
@@ -396,7 +396,7 @@ std::string SGTELIB::test_pxx (const std::string & s , const SGTELIB::Matrix & X
           break;
         default:
           std::cout << "ERROR k = " << k << "\n";
-          exit(0.0);
+          exit(0);
 
       }// end switch
 
@@ -443,7 +443,7 @@ std::string SGTELIB::test_update (const std::string & s , const SGTELIB::Matrix 
   bool ready;
   ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_update: model ("+s+") is not ready\n";
     return       "test_update: model ("+s+") is not ready\n";
@@ -529,14 +529,17 @@ std::string SGTELIB::test_singular_data (const std::string & s ) {
   // Column 0 of Z0 is constant (= 0.0);
   Z0.set_col(0.0,0);
   // Column 1 of Z0 has some nan
-  Z0.set(2,1,0.0/0.0);
-  Z0.set(5,1,0.0/0.0);
+  // Z0.set(2,1,0.0/0.0);
+  // Z0.set(5,1,0.0/0.0);
+  Z0.set(2,1,SGTELIB::NaN);
+  Z0.set(5,1,SGTELIB::NaN);
   // Column 2 of Z0 has some inf
   Z0.set(4,2,SGTELIB::INF);
   Z0.set(7,2,SGTELIB::INF);
   // Column 3 of Z0 has some nan and some inf
   Z0.set(5,3,SGTELIB::INF);
-  Z0.set(8,3,0.0/0.0);
+  Z0.set(8,3,SGTELIB::NaN);
+  // Z0.set(8,3,0.0/0.0);
   
   #ifdef SGTELIB_DEBUG
     X0.display(std::cout);  
@@ -549,7 +552,7 @@ std::string SGTELIB::test_singular_data (const std::string & s ) {
   S0 = SGTELIB::Surrogate_Factory(C0,s);
   bool ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_singular_data: model ("+s+") is not ready\n";
     return       "test_singular_data: model ("+s+") is not ready\n";
@@ -580,10 +583,10 @@ std::string SGTELIB::test_singular_data (const std::string & s ) {
   oss << "---|--------------|--------------|\n";
 
   for (int j=0 ; j<m ; j++){
-    if ( (not isdef(rmse[j])) or (not isdef(rmse[j])) ){
+    if ( ( !  isdef(rmse[j])) || ( !  isdef(rmse[j])) ){
       std::cout << "There are some nan !";
       C0.get_matrix_Xs().display(std::cout);
-      exit(0.0);
+      exit(0);
     }
   }
 
@@ -620,7 +623,7 @@ std::string SGTELIB::test_scale (const std::string & s , const SGTELIB::Matrix &
   S0 = SGTELIB::Surrogate_Factory(C0,s);
   ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_scale: model ("+s+") is not ready\n";
     return       "test_scale: model ("+s+") is not ready\n";
@@ -741,13 +744,13 @@ std::string SGTELIB::test_dimension (const std::string & s ){
   std::cout << s << "\n";
 
   // INIT DATA
-  int p,n,m,pxx=1;
+  int p =0,n=0,m=0,pxx=1;
 
   bool ready;
 
   // Training Set and Surrogate
-  SGTELIB::TrainingSet * C0;
-  SGTELIB::Surrogate * S0;
+  SGTELIB::TrainingSet * C0=NULL;
+  SGTELIB::Surrogate * S0=NULL;
 
   // Predictions
   SGTELIB::Matrix X0,Z0;
@@ -881,7 +884,7 @@ std::string SGTELIB::test_rmse (const std::string & s , const SGTELIB::Matrix & 
   S0 = SGTELIB::Surrogate_Factory(C0,s);
   ready = S0->build();
 
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_rmse: model ("+s+") is not ready\n";
     return       "test_rmse: model ("+s+") is not ready\n";
@@ -984,7 +987,7 @@ std::string SGTELIB::test_rmsecv (const std::string & s , const SGTELIB::Matrix 
   S0->get_param().get_kernel_coef();
 
   // Check ready
-  if (not ready){
+  if ( !  ready){
     surrogate_delete(S0);
     std::cout << "test_rmsecv: model ("+s+") is not ready\n";
     return       "test_rmsecv: model ("+s+") is not ready\n";
@@ -1140,7 +1143,7 @@ std::string SGTELIB::test_multiple_occurrences (const std::string & s ){
 
 
   // Check ready
-  if (not ready){
+  if ( ! ready){
     surrogate_delete(S0);
     std::cout << "test_rmsecv: model ("+s+") is not ready\n";
     return       "test_rmsecv: model ("+s+") is not ready\n";
@@ -1315,7 +1318,7 @@ double SGTELIB::test_functions_1D (const double t, const int function_index){
     case 2:
       return 0.5-exp(-10*t*t); // bump
     case 3:
-      return 0.5-((t>-0.2)and(t<0.5)); // square
+      return 0.5-((t>-0.2) && (t<0.5)); // square
     case 4:
       return 5.0*t-17.0*pow(t,3)+13*pow(t,5); // Oscillations/polynomial
     case 5:
@@ -1348,11 +1351,11 @@ SGTELIB::Matrix SGTELIB::test_functions_1D (const SGTELIB::Matrix & T, const int
 /*----------------------------------------------------*/
 void SGTELIB::check_matrix_diff(const SGTELIB::Matrix * A, const SGTELIB::Matrix * B){
   // Check not NULL
-  if (not A){
+  if ( !  A){
     std::cout << "A is NULL\n";
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"check_matrix_diff : A is NULL" );
   }
-  if (not B){
+  if ( !  B){
     std::cout << "B is NULL\n";
     throw SGTELIB::Exception ( __FILE__ , __LINE__ ,"check_matrix_diff : B is NULL" );
   }
@@ -1383,19 +1386,19 @@ void SGTELIB::check_matrix_diff(const SGTELIB::Matrix * A, const SGTELIB::Matrix
         eij = true;
         std::cout << "diff is too big !\n";
       }
-      if (std::isnan(va)){
+      if (isnan(va)){
         eij = true;
         std::cout << "va is nan !\n";
       }
-      if (std::isnan(vb)){
+      if (isnan(vb)){
         eij = true;
         std::cout << "vb is nan !\n";
       }
-      if (std::isinf(va)){
+      if (isinf(va)){
         eij = true;
         std::cout << "va is inf !\n";
       }
-      if (std::isinf(vb)){
+      if (isinf(vb)){
         eij = true;
         std::cout << "vb is inf !\n";
       }
@@ -1435,7 +1438,7 @@ void SGTELIB::build_test_data ( const std::string & function_name ,
   int n = 0;
   int m = 0;
 
-  if ( (function_name=="hartman3") or (function_name=="hartman6") ){
+  if ( (function_name=="hartman3") || (function_name=="hartman6") ){
     int q = 0;    
     SGTELIB::Matrix B,D;
     std::string B_str,D_str;
@@ -1495,7 +1498,7 @@ void SGTELIB::build_test_data ( const std::string & function_name ,
   }// end hartman
 
 
-  if ((function_name=="branin-hoo") or (function_name=="braninhoo")) {
+  if ((function_name=="branin-hoo") || (function_name=="braninhoo")) {
     n = 2;
     m = 1;
     p = 100*(n+1);

--- a/src/Tests.hpp
+++ b/src/Tests.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/TrainingSet.cpp
+++ b/src/TrainingSet.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -181,14 +181,14 @@ void SGTELIB::TrainingSet::set_bbo_type (const std::string & line){
       throw Exception ( __FILE__ , __LINE__ ,
            "TrainingSet::set_bbo_type: string error (j>_m)" );
     }
-    if ( (streqi(s,"OBJ")) or (streqi(s,"O")) ){
+    if ( (streqi(s,"OBJ")) || (streqi(s,"O")) ){
       _bbo[j] = BBO_OBJ;
       _j_obj = j;
     }
-    else if ( (streqi(s,"CON")) or (streqi(s,"C")) ){
+    else if ( (streqi(s,"CON")) || (streqi(s,"C")) ){
       _bbo[j] = BBO_CON;
     }
-    else if ( (streqi(s,"DUM")) or (streqi(s,"D")) ){
+    else if ( (streqi(s,"DUM")) || (streqi(s,"D")) ){
       _bbo[j] = BBO_DUM;
     }
     else{
@@ -254,7 +254,7 @@ void SGTELIB::TrainingSet::build ( void ){
     throw Exception ( __FILE__ , __LINE__ ,
              "TrainingSet::build(): empty training set");
 
-  if (not _ready){
+  if ( ! _ready){
     #ifdef SGTELIB_DEBUG
       std::cout << "TrainingSet::build BEGIN, X:(" << _p << "," << _n << ") Z:(" << _p << "," << _m << ")\n";
     #endif
@@ -305,7 +305,7 @@ void SGTELIB::TrainingSet::build ( void ){
 /*  Check if the training set is ready  */
 /*--------------------------------------*/
 void SGTELIB::TrainingSet::check_ready (void) const{
-  if (not _ready){
+  if ( ! _ready){
     std::cout << "TrainingSet: NOT READY!\n";
     throw Exception ( __FILE__ , __LINE__ , "TrainingSet::check_ready(): TrainingSet not ready. Use method TrainingSet::build()" );
   }
@@ -318,7 +318,7 @@ void SGTELIB::TrainingSet::check_ready (const std::string & file,
 }//
 /*--------------------------------------*/
 void SGTELIB::TrainingSet::check_ready (const std::string & s) const{
-  if (not _ready){
+  if ( ! _ready){
     std::cout << "TrainingSet: NOT READY! (" << s << ")\n";
     throw Exception ( __FILE__ , __LINE__ , "TrainingSet::check_ready(): TrainingSet not ready. Use method TrainingSet::build()" );
   }
@@ -384,7 +384,7 @@ void SGTELIB::TrainingSet::check_singular_data ( void ){
   // Check that all the _X data are defined
   for ( j = 0 ; j < _n ; j++ ) {
     for ( i = 0 ; i < _p ; i++ ) {
-      if (not isdef(_X.get(i,j))){
+      if ( ! isdef(_X.get(i,j))){
         std::cout << "_X(" << i << "," << j << ") = " << _X.get(i,j) << "\n";
         e = true;
       }
@@ -404,7 +404,7 @@ void SGTELIB::TrainingSet::check_singular_data ( void ){
       }
     }
     // if there is more than 10 points and no correct value was found, return an error.
-    if ( (_p>10) and (not isdef_Zj) ){
+    if ( (_p>10) && ( ! isdef_Zj) ){
       std::cout << "_Z(:," << j << ") has no defined value !\n";
       e = true; 
     }
@@ -449,7 +449,7 @@ void SGTELIB::TrainingSet::compute_mean_std ( void ){
     mu = 0;
     for ( i=0 ; i<_p ; i++ ) {
       v = _Z.get(i,j);
-      if (not isdef(v)) v = _Z_replace[j];
+      if ( ! isdef(v)) v = _Z_replace[j];
       mu += v;
     }
     mu /= _p; 
@@ -458,7 +458,7 @@ void SGTELIB::TrainingSet::compute_mean_std ( void ){
     var = 0;
     for ( i=0 ; i<_p ; i++ ) {
       v = _Z.get(i,j);
-      if (not isdef(v)) v = _Z_replace[j];
+      if ( ! isdef(v)) v = _Z_replace[j];
       var += (v-mu)*(v-mu);
     }
     var /= (_p-1);
@@ -503,7 +503,7 @@ void SGTELIB::TrainingSet::compute_bounds ( void ){
 
     // Compute replacement value for undef Z
     // If there are no correct bounds defined yet
-    if ( (not isdef(_Z_lb[j])) or (not isdef(_Z_ub[j])) ){
+    if ( ( ! isdef(_Z_lb[j])) || ( ! isdef(_Z_ub[j])) ){
       _Z_replace[j] = 1.0;
     }
     else{
@@ -631,7 +631,7 @@ void SGTELIB::TrainingSet::compute_scaled_matrices ( void ){
     mu = 0;
     for ( i = 0 ; i < _p ; i++ ){
       v = _Z.get(i,j);
-      if (not isdef(v)){
+      if ( ! isdef(v)){
         v = _Z_replace[j];
       }
       v = v*_Z_scaling_a[j]+_Z_scaling_b[j];
@@ -676,7 +676,7 @@ void SGTELIB::TrainingSet::compute_Ds ( void ){
     }
     // If there are some points equal to the point of index i2, 
     // then reduce the number of different points.
-    if (not unique) _pvar--;
+    if ( ! unique) _pvar--;
   }
   _Ds_mean /= double(_pvar*(_pvar-1)/2);
 
@@ -723,7 +723,7 @@ double SGTELIB::TrainingSet::get_Xs ( const int i , const int j ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(); 
     // Check index
-    if ( (i<0) or (i>=_p) or (j<0) or (j>=_n) ){
+    if ( (i<0) || (i>=_p) || (j<0) || (j>=_n) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::TrainingSet(): dimension error" );
     }
@@ -736,7 +736,7 @@ double SGTELIB::TrainingSet::get_Zs ( const int i , const int j ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(); 
     // Check index
-    if ( (i<0) or (i>=_p) or (j<0) or (j>=_m) ){
+    if ( (i<0) || (i>=_p) || (j<0) || (j>=_m) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::TrainingSet(): dimension error" );
     }
@@ -749,13 +749,13 @@ void SGTELIB::TrainingSet::get_Xs ( const int i , double * x ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(__FILE__,__FUNCTION__,__LINE__);
     // Check index
-    if ( (i<0) or (i>=_p) ){
+    if ( (i<0) || (i>=_p) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::TrainingSet(): dimension error" );
     }
   #endif
   // Check/initialize pointer
-  if (not x){
+  if ( ! x){
     x = new double [_n];
   }
   // Fill pointer
@@ -768,13 +768,13 @@ void SGTELIB::TrainingSet::get_Zs ( const int i , double * z ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(__FILE__,__FUNCTION__,__LINE__);
     // Check index
-    if ( (i<0) or (i>=_p) ){
+    if ( (i<0) || (i>=_p) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::get_Zs(): dimension error" );
     }
   #endif
   // Check/initialize pointer
-  if (not z){
+  if ( ! z){
     z = new double [_m];
   }
   // Fill pointer
@@ -787,7 +787,7 @@ double SGTELIB::TrainingSet::get_Zs_mean ( const int j ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(__FILE__,__FUNCTION__,__LINE__);
     // Check index
-    if ( (j<0) or (j>=_m) ){
+    if ( (j<0) || (j>=_m) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::get_Zs_mean(): dimension error" );
     }
@@ -801,7 +801,7 @@ int SGTELIB::TrainingSet::get_X_nbdiff ( const int i ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(__FILE__,__FUNCTION__,__LINE__);
     // Check index
-    if ( (i<0) or (i>=_n) ){
+    if ( (i<0) || (i>=_n) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::get_X_nbdiff(): dimension error" );
     }
@@ -824,7 +824,7 @@ int SGTELIB::TrainingSet::get_Z_nbdiff ( const int j ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(__FILE__,__FUNCTION__,__LINE__);
     // Check index
-    if ( (j<0) or (j>=_m) ){
+    if ( (j<0) || (j>=_m) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::get_Z_nbdiff(): dimension error" );
     }
@@ -837,7 +837,7 @@ double SGTELIB::TrainingSet::get_Ds ( const int i1 , const int i2 ) const {
   #ifdef SGTELIB_DEBUG
     check_ready(); 
     // Check index
-    if ( (i1<0) or (i1>=_p) or (i2<0) or (i2>=_p) ){
+    if ( (i1<0) || (i1>=_p) || (i2<0) || (i2>=_p) ){
       throw Exception ( __FILE__ , __LINE__ ,
                "TrainingSet::get_Ds(): dimension error" );
     }
@@ -886,7 +886,7 @@ Matrix SGTELIB::TrainingSet::get_distances ( const Matrix & A ,
             v = d*d;
             for (j=0 ; j < n ; j++){
               // If they are not in the same 0-class
-              if (  (fabs(A.get(ia,j)-x0[j])<EPSILON) xor (fabs(B.get(ib,j)-x0[j])<EPSILON)  ){
+              if (  (fabs(A.get(ia,j)-x0[j])<EPSILON) ^ (fabs(B.get(ib,j)-x0[j])<EPSILON)  ){
                 v+=10000;
               }
             }
@@ -1106,7 +1106,7 @@ double SGTELIB::TrainingSet::get_d1_over_d2 ( const Matrix & XXs ) const {
       d1=d;
       i1=i;// Memorize index of closest point
     }
-    else if ((d<d2) and (_Ds.get(i,i1)>0)){
+    else if ((d<d2) && (_Ds.get(i,i1)>0)){
       // nb: the point i can be kept as 2nd closest point only if it is different from the point 
       // i1, which means that the distance to this point must be non null.
       d2=d;
@@ -1262,7 +1262,7 @@ std::list<int> SGTELIB::TrainingSet::select_greedy ( const Matrix & X,
   const int p = X.get_nb_rows();
   const int n = X.get_nb_cols();
 
-  if ( pS<3 or pS>=p ){
+  if ( pS<3 || pS>=p ){
     std::cout << "pS = " << pS << "\n";
     throw Exception ( __FILE__ , __LINE__ ,"TrainingSet::TrainingSet(): wrong value of pS" );
   }

--- a/src/TrainingSet.hpp
+++ b/src/TrainingSet.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/sgtelib.cpp
+++ b/src/sgtelib.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -22,7 +22,6 @@
 /*                                                                                     */
 /*  You can find information on sgtelib at https://github.com/bastientalgorn/sgtelib   */
 /*-------------------------------------------------------------------------------------*/
-#include <unistd.h>
 #include "sgtelib.hpp"
 #include "Surrogate_Factory.hpp"
 #include "Surrogate_Utils.hpp"
@@ -77,7 +76,7 @@ int main ( int argc , char ** argv ) {
   //============================================
   keyword.push_back("-model");
   keyword.push_back("-verbose");
-  const int NKW = keyword.size();
+  const int NKW = static_cast<int>(keyword.size());
   // Create empty strings to store the information following each keyword.
   std::vector<std::string> info;
   for (i=0 ; i<NKW ; i++){
@@ -107,7 +106,7 @@ int main ( int argc , char ** argv ) {
     }
     // Then continue ready the words for the current keyword.
     info.at(j) += " ";
-    if (not found_kw) info.at(j) += std::string(argv[i]);
+    if ( ! found_kw) info.at(j) += std::string(argv[i]);
     i++;
   }
 
@@ -185,7 +184,7 @@ int main ( int argc , char ** argv ) {
   //============================================ 
   // help
   //============================================ 
-  if (!strcmp(action.c_str(),"-help") or error){
+  if (!strcmp(action.c_str(),"-help") || error){
     std::string model;
     for (i=0 ; i<NKW ; i++) {
       if (!strcmp(keyword.at(i).c_str(),"-help")) break;
@@ -227,7 +226,7 @@ void SGTELIB::sgtelib_predict( const std::string & file_list , const std::string
   std::string file;
   SGTELIB::Matrix X,Z,XX,ZZ;
   std::istringstream in_line (file_list);	
-  if ( (not error) and (in_line >> file) and (SGTELIB::exists(file)) ){
+  if ( ( ! error) && (in_line >> file) && (SGTELIB::exists(file)) ){
     std::cout << "Read file " << file << "\n";
     X = SGTELIB::Matrix(file);
     //X.display(std::cout);
@@ -236,7 +235,7 @@ void SGTELIB::sgtelib_predict( const std::string & file_list , const std::string
     std::cout << "Could not find " << file << "\n";
     error = true;
   }
-  if ( (not error) and (in_line >> file) and (SGTELIB::exists(file)) ){
+  if ( ( ! error) && (in_line >> file) && (SGTELIB::exists(file)) ){
     std::cout << "Read file " << file << "\n";
     Z = SGTELIB::Matrix(file);
     //Z.display(std::cout);
@@ -245,7 +244,7 @@ void SGTELIB::sgtelib_predict( const std::string & file_list , const std::string
     std::cout << "Could not find " << file << "\n";
     error = true;
   }
-  if ( (not error) and  (in_line >> file) and (SGTELIB::exists(file)) ){
+  if ( ( ! error) &&  (in_line >> file) && (SGTELIB::exists(file)) ){
     std::cout << "Read file " << file << "\n";
     XX = SGTELIB::Matrix(file);
     //XX.display(std::cout);
@@ -254,11 +253,11 @@ void SGTELIB::sgtelib_predict( const std::string & file_list , const std::string
     std::cout << "Could not find " << file << "\n";
     error = true;
   }
-  if (not (in_line >> file)){
+  if ( ! (in_line >> file)){
     std::cout << "No zz file (display output in terminal)\n";
     file = "null";
   }
-  if (not error){
+  if ( ! error){
     SGTELIB::TrainingSet TS(X,Z);
     SGTELIB::Surrogate * S = Surrogate_Factory(TS,model);
     S->build();
@@ -292,7 +291,7 @@ void SGTELIB::sgtelib_best( const std::string & file_list , const bool verbose){
   std::string file;
   SGTELIB::Matrix X,Z;
   std::istringstream in_line (file_list);	
-  if ( (not error) and (in_line >> file) and (SGTELIB::exists(file)) ){
+  if ( ( ! error) && (in_line >> file) && (SGTELIB::exists(file)) ){
     std::cout << "Read file " << file << "\n";
     X = SGTELIB::Matrix(file);
   }
@@ -300,7 +299,7 @@ void SGTELIB::sgtelib_best( const std::string & file_list , const bool verbose){
     std::cout << "Could not find " << file << "\n";
     error = true;
   }
-  if ( (not error) and (in_line >> file) and (SGTELIB::exists(file)) ){
+  if ( ( ! error) && (in_line >> file) && (SGTELIB::exists(file)) ){
     std::cout << "Read file " << file << "\n";
     Z = SGTELIB::Matrix(file);
   }
@@ -425,7 +424,7 @@ void SGTELIB::sgtelib_server( const std::string & model , const bool verbose ){
       if (display) Z.display_short(std::cout);
       std::cout << X.get_nb_rows() << " new data points...\n";
 
-      if (not S){
+      if ( ! S){
         if (display) std::cout << "First data: Build Trainig Set & Model\n";
         TS = new SGTELIB::TrainingSet(X,Z);
         S = Surrogate_Factory(*TS,model);
@@ -507,7 +506,7 @@ void SGTELIB::sgtelib_server( const std::string & model , const bool verbose ){
 
       bool ready = false;
       if (S) ready = S->build();      
-      if (not ready){
+      if ( ! ready){
         if (display) std::cout << "Surrogate not ready\n";
         dummy_str = system("touch flag_not_ready");
       }
@@ -559,7 +558,7 @@ void SGTELIB::sgtelib_server( const std::string & model , const bool verbose ){
 
       bool ready = false;
       if (S) ready = S->build();      
-      if (not ready){
+      if ( ! ready){
         if (display) std::cout << "Surrogate not ready\n";
         dummy_str = system("touch flag_not_ready");
       }
@@ -608,7 +607,7 @@ void SGTELIB::sgtelib_server( const std::string & model , const bool verbose ){
 
       bool ready = false;
       if (S) ready = S->build();      
-      if (not ready){
+      if ( ! ready){
         if (display) std::cout << "Surrogate not ready\n";
         dummy_str = system("touch flag_not_ready");
       }
@@ -708,7 +707,7 @@ void SGTELIB::sgtelib_help( std::string word ){
     // j=1 => search in associated keywords
     // j=2 => search in content
     for (i=0 ; i<NL ; i++){
-      if ( (SGTELIB::string_find(DATA[i][j],word)) or (streqi(word,"ALL")) ){
+      if ( (SGTELIB::string_find(DATA[i][j],word)) || (streqi(word,"ALL")) ){
         //std::cout << i << " " << j << " " << (SGTELIB::string_find(DATA[i][j],word)) << " " << word << " " << DATA[i][j] << "\n";
         std::cout << "===============================================\n\n";
         std::cout << "  \33[4m" << DATA[i][0] << "\33[0m" << "\n\n";

--- a/src/sgtelib.hpp
+++ b/src/sgtelib.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */

--- a/src/sgtelib_help.cpp
+++ b/src/sgtelib_help.cpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */
@@ -146,8 +146,6 @@ std::string ** SGTELIB::get_help_data (void){
 "Authorized fields for this type of model  \n"
 " * DEGREE (Can be optimized) \n"
 " * RIDGE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE PRS DEGREE 2\n"
@@ -163,8 +161,6 @@ std::string ** SGTELIB::get_help_data (void){
 "Authorized fields for this type of model  \n"
 " * DEGREE (Can be optimized) \n"
 " * RIDGE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE PRS_EDGE DEGREE 2\n"
@@ -180,8 +176,6 @@ std::string ** SGTELIB::get_help_data (void){
 "Authorized fields for this type of model  \n"
 " * DEGREE (Can be optimized) \n"
 " * RIDGE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE PRS_CAT DEGREE 2\n"
@@ -200,8 +194,6 @@ std::string ** SGTELIB::get_help_data (void){
 " * DISTANCE_TYPE (Can be optimized) \n"
 " * RIDGE (Can be optimized) \n"
 " * PRESET: \"O\" for RBF with linear terms and orthogonal constraints, \"R\" for RBF with linear terms and regularization term, \"I\" for RBF with incomplete set of basis functions. This parameter cannot be optimized. \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE RBF KERNEL_TYPE D1 KERNEL_SHAPE OPTIM DISTANCE_TYPE NORM2";
@@ -217,8 +209,6 @@ std::string ** SGTELIB::get_help_data (void){
 " * KERNEL_TYPE (Can be optimized) \n"
 " * KERNEL_COEF (Can be optimized) \n"
 " * DISTANCE_TYPE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE KS KERNEL_TYPE OPTIM KERNEL_SHAPE OPTIM";
@@ -233,8 +223,6 @@ std::string ** SGTELIB::get_help_data (void){
 "Authorized fields for this type of model  \n"
 " * RIDGE (Can be optimized) \n"
 " * DISTANCE_TYPE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
 "      TYPE KRIGING";
@@ -252,13 +240,9 @@ std::string ** SGTELIB::get_help_data (void){
 " * KERNEL_TYPE (Can be optimized) \n"
 " * KERNEL_COEF (Can be optimized) \n"
 " * DISTANCE_TYPE (Can be optimized) \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
-"      TYPE LOWESS DEGREE 1\n"
-"      TYPE LOWESS DEGREE OPTIM KERNEL_SHAPE OPTIM KERNEL_TYPE D1\n"
-"      TYPE LOWESS DEGREE OPTIM KERNEL_SHAPE OPTIM KERNEL_TYPE OPTIM DISTANCE_TYPE OPTIM";
+"      TYPE LOWESS DEGREE 1      TYPE LOWESS DEGREE OPTIM KERNEL_SHAPE OPTIM KERNEL_TYPE D1      TYPE LOWESS DEGREE OPTIM KERNEL_SHAPE OPTIM KERNEL_TYPE OPTIM DISTANCE_TYPE OPTIM";
   i++;
   //================================
   //      ENSEMBLE
@@ -270,13 +254,9 @@ std::string ** SGTELIB::get_help_data (void){
 "Authorized fields for this type of model  \n"
 " * WEIGHT: Defines how the ensemble weights are computed. \n"
 " * METRIC: Defines which metric is used to compute the weights. \n"
-" * BUDGET: Defines the budget allocated for parameter optimization. \n"
-" * DISTANCE_TYPE: This parameter is transfered to the models contained in the Ensemble. \n"
-" * OUTPUT: Defines the output text file. \n"
 " \n"
 "Example\n"
-"      TYPE ENSEMBLE WEIGHT SELECT METRIC OECV\n"
-"      TYPE ENSEMBLE WEIGHT OPTIM METRIC RMSECV DISTANCE_TYPE NORM2 BUDGET 100";
+"      TYPE ENSEMBLE WEIGHT SELECT METRIC OECV      TYPE ENSEMBLE WEIGHT OPTIM METRIC RMSECV DISTANCE_TYPE NORM2 BUDGET 100";
   i++;
   //================================
   //      TYPE
@@ -391,7 +371,8 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "WEIGHT";
   HELP_DATA[i][1] = "ENSEMBLE SELECTION WTA1 WTA2 WTA3 WTA4 WTA";
-  HELP_DATA[i][2] = "The field name WEIGHT defines the method used to compute the weights w of the ensemble of models. The keyword WEIGHT_TYPE is equivalent. \n"
+  HELP_DATA[i][2] = "The field name WEIGHT defines the method used to compute the weights w of the ensemble of models. The keyword WEIGHT_TYPE is equivalent. Allowed for models of type ENSEMBLE.\n"
+" \n"
 "Allowed for models of type ENSEMBLE. \n"
 " \n"
 "Possible values  \n"
@@ -409,8 +390,7 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "OUTPUT";
   HELP_DATA[i][1] = "OUT DISPLAY";
-  HELP_DATA[i][2] = "Defines a text file in which model information are recorded. \n"
-"Allowed for ALL types of model";
+  HELP_DATA[i][2] = "Defines a text file in which informations will be recorded.";
   i++;
   //================================
   //      OPTIM
@@ -437,7 +417,7 @@ std::string ** SGTELIB::get_help_data (void){
   HELP_DATA[i][1] = "PARAMETER OPTIMIZATION CHOICE SELECTION OPTIM BUDGET ENSEMBLE";
   HELP_DATA[i][2] = "The field name METRIC defines the metric used to select the parameters of the model (including the weights of Ensemble models).\n"
 " \n"
-"Allowed for ALL types of model\n"
+"Allowed for models of type All types of model.\n"
 " \n"
 "Possible values  \n"
 " * EMAX: Error Max \n"
@@ -461,8 +441,6 @@ std::string ** SGTELIB::get_help_data (void){
   HELP_DATA[i][0] = "BUDGET";
   HELP_DATA[i][1] = "PARAMETER PARAMETERS OPTIM OPTIMIZATION";
   HELP_DATA[i][2] = "Budget for model parameter optimization. The number of sets of model parameters that are tested is equal to the optimization budget multiplied by the the number of parameters to optimize. \n"
-"Allowed for ALL types of model\n"
-" \n"
 "Default values 20\n"
 " \n"
 "Example\n"
@@ -474,8 +452,7 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_START";
   HELP_DATA[i][1] = "Matlab server interface";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Start a sgtelib model in a server from Matlab. \n"
+  HELP_DATA[i][2] = "Start a sgtelib model in a server from Matlab. \n"
 " \n"
 "Example\n"
 "       sgtelib_server_start('TYPE PRS'); Start a sgtelib server with a PRS model\n"
@@ -487,8 +464,7 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_NEWDATA";
   HELP_DATA[i][1] = "Matlab server interface data newdata";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Add data points to the sgtelib model from Matlab. \n"
+  HELP_DATA[i][2] = "Add data points to the sgtelib model from Matlab. \n"
 " \n"
 "Example\n"
 "       sgtelib_server_newdata(X,Z); Add data points [X,Z]";
@@ -498,8 +474,7 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_PREDICT";
   HELP_DATA[i][1] = "Matlab server interface prediction predict";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Perform a prediction from Matlab.\n"
+  HELP_DATA[i][2] = "Perform a prediction from Matlab.\n"
 " \n"
 "Example\n"
 "       [ZZ,std,ei,cdf] = sgtelib_server_predict(XX); Prediction at points XX.";
@@ -509,16 +484,14 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_INFO";
   HELP_DATA[i][1] = "Matlab server interface";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Use sgtelib_server_info to display information about the model.";
+  HELP_DATA[i][2] = "Command from Matlab. Use sgtelib_server_info to display information about the model.";
   i++;
   //================================
   //      SGTELIB_SERVER_METRIC
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_METRIC";
   HELP_DATA[i][1] = "Matlab server interface RMSE OECV RMSECV OE METRIC";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Use sgtelib_server_stop(metric_name) to access the error metric of the model.\n"
+  HELP_DATA[i][2] = "Command from Matlab. Use sgtelib_server_stop(metric_name) to access the error metric of the model.\n"
 " \n"
 "Example\n"
 "       m = sgtelib_server_metric('OECV'); Return the OECV error metric\n"
@@ -529,16 +502,14 @@ std::string ** SGTELIB::get_help_data (void){
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_RESET";
   HELP_DATA[i][1] = "Matlab server interface reset";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Reset the model of the sgtelib server from Matlab.";
+  HELP_DATA[i][2] = "Reset the model of the sgtelib server from Matlab.";
   i++;
   //================================
   //      SGTELIB_SERVER_STOP
   //================================
   HELP_DATA[i][0] = "SGTELIB_SERVER_STOP";
   HELP_DATA[i][1] = "Matlab server interface stop";
-  HELP_DATA[i][2] = "Command from Matlab. See example directory for more details.\n"
-" Stop the sgtelib server from Matlab.";
+  HELP_DATA[i][2] = "Stop the sgtelib server from Matlab.";
   i++;
   //================================
   return HELP_DATA;

--- a/src/sgtelib_help.hpp
+++ b/src/sgtelib_help.hpp
@@ -2,7 +2,7 @@
 /*  sgtelib - A surrogate model library for derivative-free optimization               */
 /*  Version 2.0.1                                                                      */
 /*                                                                                     */
-/*  Copyright (C) 2012-2016  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
+/*  Copyright (C) 2012-2017  Sebastien Le Digabel - Ecole Polytechnique, Montreal      */ 
 /*                           Bastien Talgorn - McGill University, Montreal             */
 /*                                                                                     */
 /*  Author: Bastien Talgorn                                                            */


### PR DESCRIPTION
Replace logical operators (and, or, xor, not,...) by (&&, ||, !)
Fix a memory leak observed when testing with Nomad.3.8.0
 