### PR TITLE
quiet compilation warning

### DIFF
--- a/src/Surrogate.cpp
+++ b/src/Surrogate.cpp
@@ -1339,7 +1339,7 @@ bool SGTELIB::Surrogate::optimize_parameters ( void ) {
       int i2;
       for (j=1; j<N; j++){
         for (i=0; i<nx0; i++){
-          i2 = i+std::floor(uniform_rand()*(nx0-i));
+          i2 = i + (int)std::floor(uniform_rand()*(nx0-i));
           if ( (i2<i) || (i2>=nx0) ){
             std::cout << "Error in permutation indexes\n";
             exit(0);


### PR DESCRIPTION
Bonjour Bastien!
On est en train de préparer le release 3.9 de NOMAD et voici un warning de compilation à enlever.
Je pense que Christophe est en train de préparer d'autres changements (dll).
Viviane 😃 