### PR TITLE
Remove code using deprecated function

### DIFF
--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -1576,30 +1576,6 @@ SGTELIB::Matrix SGTELIB::Matrix::ones ( const int nbRows , const int nbCols ) {
 }//
 
 /*---------------------------*/
-/* random permutation matrix */
-/*---------------------------*/
-// Create a square matrix of size nbCols, with one 1.0 randomly 
-// placed in each col and in each row
-SGTELIB::Matrix SGTELIB::Matrix::random_permutation_matrix ( const int n ) {
-  // Init matrix
-  SGTELIB::Matrix perm("perm",n,n);
-
-  // Create random integer permutation
-  std::vector<int> v;
-
-  // Create order vector
-  for (int i=0; i<n; ++i) v.push_back(i); // 1 2 3 4 5 6 7 8 9
-
-  // shuffle
-  std::random_shuffle ( v.begin(), v.end() );
-
-  // Fill matrix
-  for (int i=0; i<n; ++i) perm.set(i,v[i],1.0);
-
-  return perm;
-}//
-
-/*---------------------------*/
 /* rank                      */
 /*---------------------------*/
 SGTELIB::Matrix SGTELIB::Matrix::rank ( void ) const {

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -277,9 +277,6 @@ namespace SGTELIB {
     // ones matrix
     static SGTELIB::Matrix ones ( const int nbRows , const int nbCols );
 
-    // random permutation matrix
-    static SGTELIB::Matrix random_permutation_matrix ( const int n );
-
     // Lines random permutation
     SGTELIB::Matrix random_line_permutation ( void ) const;
 


### PR DESCRIPTION
Issue: using std::random_shuffle() gives compilation warnings since it is deprecated in c++14, and removed in c++17.
Suggested fix: Remove method Matrix::random_permutation_matrix(), since it is not used, and it is the only one that uses deprecated function std::random_shuffle().

In NOMAD 4, we fixed a similar issue by updating our random number generator RNG and using in std::shuffle() instead of random_shuffle.

Since sgtelib does not seem to have its own random number generator, and since random_permutation_matrix is not used, after discussion with @ctribes we thought the simplest solution is to remove method random_permutation_matrix().