### PR TITLE
Change how check_singular_data behaves

### DIFF
--- a/src/TrainingSet.cpp
+++ b/src/TrainingSet.cpp
@@ -272,8 +272,14 @@ void SGTELIB::TrainingSet::build ( void ){
       if (_X_nbdiff[j]>2) _X_nbdiff2++;
     }
 
-    // Check singular data (inf and void) 
-    check_singular_data();
+    // Check singular data (inf and void)
+    if (check_singular_data())
+    {
+    #ifdef SGTELIB_DEBUG
+        std::cout << "SGTELIB::TrainingSet::check_singular_data(): incorrect data. Some _Z has no defined value !\n";
+    #endif
+        return;
+    }
 
     // Compute bounds over columns of X and Z
     compute_bounds();
@@ -399,49 +405,45 @@ bool SGTELIB::TrainingSet::add_point ( const double * xnew ,
                       Matrix::row_vector ( znew , _m ) );
 }//
 
-
 /*---------------------------------------------------*/
 /*  compute the mean and std over                    */
 /*  the columns of a matrix                          */
 /*---------------------------------------------------*/
-void SGTELIB::TrainingSet::check_singular_data ( void ){
-
-  int i,j;
-  bool e = false;
-  // Check that all the _X data are defined
-  for ( j = 0 ; j < _n ; j++ ) {
-    for ( i = 0 ; i < _p ; i++ ) {
-      if ( ! isdef(_X.get(i,j))){
-        std::cout << "_X(" << i << "," << j << ") = " << _X.get(i,j) << "\n";
-        e = true;
-      }
+bool SGTELIB::TrainingSet::check_singular_data ( void ){
+    
+    int i,j;
+    bool e = false;
+    // Check that all the _X data are defined
+    for ( j = 0 ; j < _n ; j++ ) {
+        for ( i = 0 ; i < _p ; i++ ) {
+            if ( ! isdef(_X.get(i,j))){
+                std::cout << "_X(" << i << "," << j << ") = " << _X.get(i,j) << "\n";
+                e = true;
+            }
+        }
     }
-  }
-
-  // Check that, for each output index, SOME data are defined
-  bool isdef_Zj; // True if at least one value is defined for output j.
-  // Loop on the output indexes
-  for ( j = 0 ; j < _m ; j++ ) {
-    // no def value so far
-    isdef_Zj = false;
-    for ( i = 0 ; i < _p ; i++ ) {
-      if (isdef(_Z.get(i,j))){
-        isdef_Zj = true;
-        break;
-      }
+    
+    // Check that, for each output index, SOME data are defined
+    bool isdef_Zj; // True if at least one value is defined for output j.
+    // Loop on the output indexes
+    for ( j = 0 ; j < _m ; j++ ) {
+        // no def value so far
+        isdef_Zj = false;
+        for ( i = 0 ; i < _p ; i++ ) {
+            if (isdef(_Z.get(i,j))){
+                isdef_Zj = true;
+                break;
+            }
+        }
+        // if there is more than 10 points and no correct value was found, return flag error.
+        if ( (_p>10) && ( ! isdef_Zj) ){
+            e = true;
+        }
     }
-    // if there is more than 10 points and no correct value was found, return an error.
-    if ( (_p>10) && ( ! isdef_Zj) ){
-      std::cout << "_Z(:," << j << ") has no defined value !\n";
-      e = true; 
-    }
-  }
-
-  if (e){
-    throw Exception ( __FILE__ , __LINE__ , "TrainingSet::check_singular_data(): incorrect data !" );
-  }
-
-}//
+    
+    return e;
+    
+}////
 
 /*---------------------------------------------------*/
 /*  compute the mean and std over                    */

--- a/src/TrainingSet.cpp
+++ b/src/TrainingSet.cpp
@@ -443,7 +443,7 @@ bool SGTELIB::TrainingSet::check_singular_data ( void ){
     
     return e;
     
-}////
+}//
 
 /*---------------------------------------------------*/
 /*  compute the mean and std over                    */

--- a/src/TrainingSet.hpp
+++ b/src/TrainingSet.hpp
@@ -111,7 +111,7 @@ namespace SGTELIB {
     void compute_Ds              (void);
     void compute_scaled_matrices (void);
     void compute_f_min           (void);
-    void check_singular_data     (void);
+    bool check_singular_data     (void);
 
     // FORBIDEN copy constructor:
     TrainingSet ( const TrainingSet & );


### PR DESCRIPTION
When having singular data, no need to trigger exception. The model cannot be built.
This was problematic for some optimization runs with many points with large absolute values.