### PR TITLE
Fix for Surrogate::build()

### DIFF
--- a/src/Surrogate.cpp
+++ b/src/Surrogate.cpp
@@ -202,6 +202,11 @@ bool SGTELIB::Surrogate::build ( void ) {
   // Before building the surrogate, the trainingset must be ready
   _trainingset.build();
 
+   if (!_trainingset.is_ready()) {
+     _ready = false;
+     return false;
+   }
+
   // Number of points in the training set.
   _p_ts = _trainingset.get_nb_points();
   //std::cout << _ready << " " << _p_ts << " " << _p_ts_old << "\n";


### PR DESCRIPTION
If the training set's  build method was called, but the training set is not ready, set Surrogate as not ready and exit its build.

This happens very rarely. I had this bug while running lots of tests, and after thousands of evaluations, and I had not seen it before.